### PR TITLE
Fix reminders showing the wrong time on iCloud Web (set dueDateComponents.timeZone)

### DIFF
--- a/Sources/EventKitManager.swift
+++ b/Sources/EventKitManager.swift
@@ -269,10 +269,16 @@ class EventKitManager {
         reminder.notes = notes
 
         if let dueDate = dueDate {
-            reminder.dueDateComponents = Calendar.current.dateComponents(
+            var dueComponents = Calendar.current.dateComponents(
                 [.year, .month, .day, .hour, .minute, .second],
                 from: dueDate
             )
+            // Attach an explicit time zone so the due date is stored zoned, not
+            // floating. A floating dueDateComponents (timeZone == nil) is rendered
+            // shifted by the host's UTC offset on iCloud Web, while native EventKit
+            // clients treat it as local time.
+            dueComponents.timeZone = TimeZone.current
+            reminder.dueDateComponents = dueComponents
         }
 
         do {


### PR DESCRIPTION
## Problem

`ekctl add reminder` stores the due date as `EKReminder.dueDateComponents` **without a time zone** (`timeZone == nil`) — a *floating* wall-clock value. Floating due dates render inconsistently across clients:

- Native EventKit clients (iPhone / macOS Reminders) interpret floating components as **local** → correct time.
- **iCloud Web** interprets them as **UTC** and converts to the browser's zone → the due time is shifted by the host's UTC offset (e.g. a 3:00 PM reminder shows as 11:00 AM on a UTC−4 host).

## Fix

Attach an explicit time zone when building `dueDateComponents` so the due date is stored *zoned* (a real instant), which every client renders consistently:

```swift
if let dueDate = dueDate {
    var dueComponents = Calendar.current.dateComponents(
        [.year, .month, .day, .hour, .minute, .second],
        from: dueDate
    )
    dueComponents.timeZone = TimeZone.current   // store zoned, not floating
    reminder.dueDateComponents = dueComponents
}
```

(Single change in `EventKitManager.addReminder`.)

## Verification

A/B test — two reminders with the same due instant, differing only in whether the stored components carried a time zone:

| Variant | `dueDateComponents.timeZone` | Native (iPhone / macOS) | iCloud Web (Firefox + Safari) |
|---|---|---|---|
| before (floating) | `nil` | correct | shifted by host offset |
| after (zoned) | `TimeZone.current` | correct | correct |

Tested on a UTC−4 (EDT) host. The same root cause was independently confirmed in another EventKit-based project (PsychQuant/che-ical-mcp#134), which uses the same API and shows the identical shift.

## Notes

- Uses `TimeZone.current` (the host's named, DST-aware zone) rather than a fixed offset.
- Scope is limited to the reminder-create path; no other behavior changes.
